### PR TITLE
Add docker support

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -22,6 +22,7 @@ services:
     environment:
       POSTGRES_USER: pgsql_feedfront
       POSTGRES_PASSWORD: pgsql_pass
+      POSTGRES_DB: feedfront
     ports:
       - "5432:5432"
     volumes:
@@ -39,6 +40,7 @@ services:
     environment:
       POSTGRES_USER: pgsql_school
       POSTGRES_PASSWORD: pgsql_pass
+      POSTGRES_DB: school
     ports:
       - "5433:5432"
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,51 @@
+services:
+  feedfront:
+    build:
+      context: ./feedfront
+      dockerfile: ./Dockerfile-prod
+    container_name: feedfront-frontend
+    ports:
+      - "3000:3000"
+  feedback:
+    build: ./feedback
+    container_name: feedfront-backend
+    ports:
+      - "3001:3000"
+  internal-database:
+    image: postgres:17
+    container_name: feedfront-internal-database
+    restart: always
+
+    # Set shared memory limit when using docker-compose. This is a good practice according to the official PostgreSQL documentation.
+    shm_size: 128mb
+
+    environment:
+      POSTGRES_USER: pgsql_feedfront
+      POSTGRES_PASSWORD: pgsql_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      # SQL script to initialize the database
+      - ./internal-db-init.sql:/docker-entrypoint-initdb.d/internal-db-init.sql
+      - internaldb:/var/lib/postgresql/data
+  school-database:
+    image: postgres:17
+    container_name: feedfront-school-database
+    restart: always
+
+    # Set shared memory limit when using docker-compose. This is a good practice according to the official PostgreSQL documentation.
+    shm_size: 128mb
+
+    environment:
+      POSTGRES_USER: pgsql_school
+      POSTGRES_PASSWORD: pgsql_pass
+    ports:
+      - "5433:5432"
+    volumes:
+      # SQL script to initialize the database
+      - ./school-db-init.sql:/docker-entrypoint-initdb.d/school-db-init.sql
+      - schooldb:/var/lib/postgresql/data
+
+volumes:
+  internaldb:
+  schooldb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  feedfront:
+    build:
+      context: ./feedfront
+      dockerfile: ./Dockerfile-dev
+    container_name: feedfront-frontend
+    ports:
+      - "3000:3000"
+  feedback:
+    build: ./feedback
+    container_name: feedfront-backend
+    ports:
+      - "3001:3000"
+  internal-database:
+    image: postgres:17
+    container_name: feedfront-internal-database
+    restart: always
+
+    # Set shared memory limit when using docker-compose. This is a good practice according to the official PostgreSQL documentation.
+    shm_size: 128mb
+
+    environment:
+      POSTGRES_USER: pgsql_feedfront
+      POSTGRES_PASSWORD: pgsql_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      # SQL script to initialize the database
+      - ./internal-db-init.sql:/docker-entrypoint-initdb.d/internal-db-init.sql
+      - internaldb:/var/lib/postgresql/data
+  school-database:
+    image: postgres:17
+    container_name: feedfront-school-database
+    restart: always
+
+    # Set shared memory limit when using docker-compose. This is a good practice according to the official PostgreSQL documentation.
+    shm_size: 128mb
+
+    environment:
+      POSTGRES_USER: pgsql_school
+      POSTGRES_PASSWORD: pgsql_pass
+    ports:
+      - "5433:5432"
+    volumes:
+      # SQL script to initialize the database
+      - ./school-db-init.sql:/docker-entrypoint-initdb.d/school-db-init.sql
+      - schooldb:/var/lib/postgresql/data
+
+volumes:
+  internaldb:
+  schooldb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       POSTGRES_USER: pgsql_feedfront
       POSTGRES_PASSWORD: pgsql_pass
+      POSTGRES_DB: feedfront
     ports:
       - "5432:5432"
     volumes:
@@ -39,6 +40,7 @@ services:
     environment:
       POSTGRES_USER: pgsql_school
       POSTGRES_PASSWORD: pgsql_pass
+      POSTGRES_DB: school
     ports:
       - "5433:5432"
     volumes:

--- a/feedback/Dockerfile
+++ b/feedback/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package.json /app
+
+RUN npm install
+
+COPY . /app
+
+CMD ["node","app.js"]

--- a/feedfront/Dockerfile-dev
+++ b/feedfront/Dockerfile-dev
@@ -1,0 +1,20 @@
+# Use the official Node.js image as the base image
+FROM node:20-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the Next.js development server
+CMD ["npm", "run", "dev"]

--- a/feedfront/Dockerfile-prod
+++ b/feedfront/Dockerfile-prod
@@ -1,0 +1,73 @@
+# syntax=docker.io/docker/dockerfile:1
+
+# This file was taken from the official NextJS documentation (https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile).
+# We did not modify it.
+
+FROM node:20-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
+RUN \
+    if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+    elif [ -f package-lock.json ]; then npm ci; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line in case you want to disable telemetry during the build.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN \
+    if [ -f yarn.lock ]; then yarn run build; \
+    elif [ -f package-lock.json ]; then npm run build; \
+    elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
+    else echo "Lockfile not found." && exit 1; \
+    fi
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=development
+# Uncomment the following line in case you want to disable telemetry during runtime.
+# ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/feedfront/next.config.ts
+++ b/feedfront/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/internal-db-init.sql
+++ b/internal-db-init.sql
@@ -1,8 +1,5 @@
 -- INITIALIZE DATABASE SCHEMA
 
--- CREATE DATABASE feedfront;
--- GRANT ALL PRIVILEGES ON DATABASE feedfront TO pgsql_feedfront;
-
 CREATE TABLE user_app (
    Id SERIAL,
    hashed_password VARCHAR(50) NOT NULL,

--- a/internal-db-init.sql
+++ b/internal-db-init.sql
@@ -1,0 +1,96 @@
+-- INITIALIZE DATABASE SCHEMA
+
+-- CREATE DATABASE feedfront;
+-- GRANT ALL PRIVILEGES ON DATABASE feedfront TO pgsql_feedfront;
+
+CREATE TABLE user_app (
+   Id SERIAL,
+   hashed_password VARCHAR(50) NOT NULL,
+   PRIMARY KEY(Id)
+);
+
+CREATE TABLE student (
+   Id INT,
+   email VARCHAR(50),
+   PRIMARY KEY(Id),
+   UNIQUE(email),
+   FOREIGN KEY(Id) REFERENCES user_app(Id)
+);
+
+CREATE TABLE teacher (
+   Id INT,
+   name VARCHAR(50),
+   lastname VARCHAR(50),
+   PRIMARY KEY(Id),
+   FOREIGN KEY(Id) REFERENCES user_app(Id)
+);
+
+CREATE TABLE admin (
+   Id INT,
+   PRIMARY KEY(Id),
+   FOREIGN KEY(Id) REFERENCES user_app(Id)
+);
+
+CREATE TABLE token_used (
+   token TEXT,
+   PRIMARY KEY(token)
+);
+
+CREATE TABLE form (
+   Id_form SERIAL,
+   course_name VARCHAR(50) NOT NULL,
+   level VARCHAR(50) NOT NULL,
+   end_date TIMESTAMP,
+   Id_admin INT NOT NULL,
+   PRIMARY KEY(Id_form),
+   UNIQUE(course_name),
+   FOREIGN KEY(Id_admin) REFERENCES admin(Id)
+);
+
+CREATE TABLE field (
+   Id_form INT,
+   Id_field SERIAL,
+   name VARCHAR(200) NOT NULL,
+   question TEXT,
+   PRIMARY KEY(Id_form, Id_field),
+   FOREIGN KEY(Id_form) REFERENCES form(Id_form)
+);
+
+CREATE TABLE response (
+   Id_response SERIAL,
+   Id_form INT NOT NULL,
+   PRIMARY KEY(Id_response),
+   FOREIGN KEY(Id_form) REFERENCES form(Id_form)
+);
+
+CREATE TABLE teacher_form (
+   Id_teacher INT,
+   Id_form INT,
+   PRIMARY KEY(Id_teacher, Id_form),
+   FOREIGN KEY(Id_teacher) REFERENCES teacher(Id),
+   FOREIGN KEY(Id_form) REFERENCES form(Id_form)
+);
+
+CREATE TABLE student_form (
+   Id_student INT,
+   Id_form INT,
+   token TEXT NOT NULL,
+   PRIMARY KEY(Id_student, Id_form),
+   UNIQUE(token),
+   FOREIGN KEY(Id_student) REFERENCES student(Id),
+   FOREIGN KEY(Id_form) REFERENCES form(Id_form)
+);
+
+CREATE TABLE note (
+   Id_form INT,
+   Id_field INT,
+   Id_response INT,
+   note DECIMAL(2, 0) NOT NULL,
+   PRIMARY KEY(Id_form, Id_field, Id_response),
+   FOREIGN KEY(Id_form, Id_field) REFERENCES field(Id_form, Id_field),
+   FOREIGN KEY(Id_response) REFERENCES response(Id_response)
+);
+
+-- INSERT SAMPLE DATA
+
+-- ...


### PR DESCRIPTION
This pull request introduces several Docker-related changes to set up and configure Docker containers for development and production environments. It also includes database initialization scripts and configuration updates for the `feedfront` application.

### Docker Setup:

* [`docker-compose-prod.yml`](diffhunk://#diff-0faee0a2e11c359bfbe8424e6a5c5a0d58881176f85af37e273497e0dad42840R1-R53): Added configuration for production services including `feedfront`, `feedback`, `internal-database`, and `school-database` with appropriate build contexts, ports, and environment variables.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R53): Added configuration for development services similar to the production setup with different Dockerfiles for `feedfront`.

### Dockerfiles:

* [`feedback/Dockerfile`](diffhunk://#diff-31dde744b71365fc4f467d6497c26e3ea8197e97681cb9b1c0085945d35ca0a8R1-R11): Added a Dockerfile for the `feedback` service using Node.js.
* [`feedfront/Dockerfile-dev`](diffhunk://#diff-5a28393fc4e72b1cf27b17b2707000a1b1aa55ff216b346979f495be420901f4R1-R20): Added a Dockerfile for the development environment of the `feedfront` service using Node.js and Next.js.
* [`feedfront/Dockerfile-prod`](diffhunk://#diff-3ba341e45435047cd2d90a00b2c076a1f2494c8dfa020f0d3f7d0c88addb6526R1-R73): Added a Dockerfile for the production environment of the `feedfront` service, based on the official Next.js example.

### Database Initialization:

* [`internal-db-init.sql`](diffhunk://#diff-a55838ac045f3ef9c701f954ef1a0688ebf8ced45545af0cca7dca787c117a48R1-R93): Added SQL script to initialize the internal database schema with tables for users, students, teachers, admins, forms, and responses.

### Configuration Updates:

* [`feedfront/next.config.ts`](diffhunk://#diff-c5c4ddb15983bebb36910b7b929083889a4d5be1d629a2040cb1e16cf9c29834L4-R4): Updated Next.js configuration to use standalone output.