### PR TITLE
Efrei API: Return courses + Add "level" field for students

### DIFF
--- a/efrei-api/src/controllers/userController.ts
+++ b/efrei-api/src/controllers/userController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import roles from "../util/roles";
-import { User } from "../util/user";
+import { Level, User } from "../util/user";
 
 // TODO: Move this somewhere else once the database is done
 const usersList: Array<User> = [
@@ -15,14 +15,23 @@ const usersList: Array<User> = [
     "pass",
     roles.TEACHER
   ),
-  new User(5, "Student", "STUDENT", "student@efrei.net", "pass", roles.STUDENT),
+  new User(
+    5,
+    "Student",
+    "STUDENT",
+    "student@efrei.net",
+    "pass",
+    roles.STUDENT,
+    Level.P1
+  ),
   new User(
     6,
     "Student2",
     "STUDENT2",
     "student2@efrei.net",
     "pass",
-    roles.STUDENT
+    roles.STUDENT,
+    Level.I2
   ),
 ];
 
@@ -122,6 +131,7 @@ export const login = (req: Request, res: Response) => {
     lastname: user.lastname,
     email: user.email,
     role: user.role,
+    level: user.level,
   });
 };
 

--- a/efrei-api/src/controllers/userController.ts
+++ b/efrei-api/src/controllers/userController.ts
@@ -26,19 +26,96 @@ const usersList: Array<User> = [
   ),
 ];
 
+const userCourses = [
+  {
+    userId: 3,
+    courses: [
+      {
+        id: 1,
+        name: "Math",
+        teachers: [3, 4],
+      },
+    ],
+  },
+  {
+    userId: 4,
+    courses: [
+      {
+        id: 1,
+        name: "Math",
+        teachers: [3, 4],
+      },
+      {
+        id: 2,
+        name: "Physics",
+        teachers: [4],
+      },
+    ],
+  },
+  {
+    userId: 5,
+    courses: [
+      {
+        id: 1,
+        name: "Math",
+        teachers: [3, 4],
+      },
+      {
+        id: 2,
+        name: "Physics",
+        teachers: [4],
+      },
+    ],
+  },
+];
+
+/**
+ * Handles user login by validating the provided email and password.
+ *
+ * @param req - The request object containing the login credentials in the body.
+ * @param res - The response object used to send back the appropriate user information or an error message.
+ *
+ * @remarks
+ * This function searches for a user in the `usersList` with the provided email and password.
+ * If a matching user is found, it returns the user's information.
+ * If no matching user is found, it returns a 401 status with an "Invalid username or password" message.
+ *
+ * @example
+ * // Example request body
+ * {
+ *   "email": "user@example.com",
+ *   "password": "password123"
+ * }
+ *
+ * // Example response for a successful login
+ * {
+ *   "id": 1,
+ *   "firstname": "John",
+ *   "lastname": "Doe",
+ *   "email": "user@example.com",
+ *   "role": "admin"
+ * }
+ *
+ * // Example response for an unsuccessful login
+ * {
+ *   "message": "Invalid username or password"
+ * }
+ */
 export const login = (req: Request, res: Response) => {
-  console.log(req.body);
+  // Get login credentials from the request body
   const { email, password } = req.body;
 
   const user = usersList.find(
     (user) => user.email === email && user.password === password
   );
 
+  // No user found with the provided credentials
   if (!user) {
     res.status(401).json({ message: "Invalid username or password" });
     return;
   }
 
+  // Return appropriate user information
   res.json({
     id: user.id,
     firstname: user.firstname,
@@ -46,4 +123,39 @@ export const login = (req: Request, res: Response) => {
     email: user.email,
     role: user.role,
   });
+};
+
+/**
+ * Retrieves the courses for a specific user based on their ID.
+ * If the user is a student, the courses returned are the ones they are enrolled in.
+ * If the user is a teacher, the courses returned are the ones they are teaching.
+ *
+ * @param req - The request object containing the user ID in the parameters.
+ * @param res - The response object used to send back the user's courses or an error message.
+ *
+ * @remarks
+ * - If the user is not found, a 404 status with a "User not found" message is returned.
+ * - If the user is an admin, a 403 status with an "Admins do not have courses" message is returned.
+ * - If the user is found and is not an admin, their courses are returned in the response.
+ *
+ * @returns The user's courses or an appropriate error message.
+ */
+export const getUserCourses = (req: Request, res: Response) => {
+  // Get the user from the id
+  const user = usersList.find((user) => user.id === +req.params.id);
+
+  // If the user is not found
+  if (!user) {
+    res.status(404).json({ message: "User not found" });
+    return;
+  }
+
+  if (user.role === roles.ADMIN) {
+    res.status(403).json({ message: "Admins do not have courses" });
+    return;
+  }
+
+  // Return the user's courses
+  const userCourseList = userCourses.find((uc) => uc.userId === user.id);
+  res.json({ courses: userCourseList?.courses || [] });
 };

--- a/efrei-api/src/routes/user.ts
+++ b/efrei-api/src/routes/user.ts
@@ -1,8 +1,15 @@
 import { Router } from "express";
-import { login } from "../controllers/userController";
+import { login, getUserCourses } from "../controllers/userController";
+import authorizations from "../util/authorizations";
+import { authenticate } from "../middlewares/authentication";
 
 const router = Router();
 
 router.post("/login", login);
+router.get(
+  "/:id/courses",
+  authenticate(authorizations.API_STUDENT_READ),
+  getUserCourses
+);
 
 export default router;

--- a/efrei-api/src/util/user.ts
+++ b/efrei-api/src/util/user.ts
@@ -1,3 +1,11 @@
+enum Level {
+  P1 = "P1",
+  P2 = "P2",
+  P3 = "P3",
+  I1 = "I1",
+  I2 = "I2",
+}
+
 class User {
   id: number;
   firstname: string;
@@ -5,6 +13,7 @@ class User {
   email: string;
   password: string;
   role: string;
+  level?: Level;
 
   constructor(
     id: number,
@@ -12,7 +21,8 @@ class User {
     lastname: string,
     email: string,
     password: string,
-    role: string
+    role: string,
+    level?: Level
   ) {
     this.id = id;
     this.firstname = firstname;
@@ -20,7 +30,8 @@ class User {
     this.email = email;
     this.password = password;
     this.role = role;
+    this.level = level ?? undefined;
   }
 }
 
-export { User };
+export { User, Level };


### PR DESCRIPTION
Changes made:
- Added the `getUserCourses` in the `user` controller
- Added the `/user/:id/courses` route
- Added documentation for the `user` controller functions
- Added the `level` field for the students in the user class (it is also now returned in the response of the `/user/login` route)

Example of a response from the `/user/:id/courses` route (in the case of a student):
<img width="490" alt="Screenshot 2024-11-21 at 08 49 37" src="https://github.com/user-attachments/assets/a72b6fd8-9f4d-49cb-a121-8bb52c29fffa">